### PR TITLE
#177 설정 페이지 사이드 메뉴의 탭 active 처리

### DIFF
--- a/src/main/java/com/pentoryall/settlement/controller/SettlementController.java
+++ b/src/main/java/com/pentoryall/settlement/controller/SettlementController.java
@@ -35,7 +35,8 @@ public class SettlementController {
     }
 
     @GetMapping("/settlement")
-    public String settlementPage(@AuthenticationPrincipal UserDTO sessionUser, Model model) {
+    public String settlementPage(@AuthenticationPrincipal UserDTO sessionUser,
+                                 Model model) {
 
         UserSettlementDTO userSettlement = userSettlementService.selectByUserCode(sessionUser.getCode());
         if (userSettlement != null) {
@@ -45,6 +46,7 @@ public class SettlementController {
             model.addAttribute("settlement", settlement);
         }
 
+        model.addAttribute("SETTINGS_ASIDE", "settlement");
         return "views/settlement/settlement";
     }
 
@@ -72,10 +74,12 @@ public class SettlementController {
     public String settlementListPage(Model model,
                                      @RequestParam(defaultValue = "1") int page,
                                      @AuthenticationPrincipal UserDTO sessionUser) {
+
         Map<String, Object> resultMap = settlementService.selectSettlementListWithPagingByUserCode(page, sessionUser.getCode());
         model.addAttribute("paging", resultMap.get("paging"));
         model.addAttribute("settlementList", resultMap.get("settlementList"));
 
+        model.addAttribute("SETTINGS_ASIDE", "settlement-list");
         return "views/settlement/settlementList";
     }
 
@@ -83,10 +87,12 @@ public class SettlementController {
     public String revenueListPage(Model model,
                                   @RequestParam(defaultValue = "1") int page,
                                   @AuthenticationPrincipal UserDTO sessionUser) {
+
         Map<String, Object> resultMap = settlementService.selectRevenueListWithPagingByUserCode(page, sessionUser.getCode());
         model.addAttribute("paging", resultMap.get("paging"));
         model.addAttribute("revenueList", resultMap.get("revenueList"));
 
+        model.addAttribute("SETTINGS_ASIDE", "revenue-list");
         return "views/settlement/revenueList";
     }
 
@@ -97,4 +103,3 @@ public class SettlementController {
         return new UsernamePasswordAuthenticationToken(newPrincipal, newPrincipal.getPassword(), newPrincipal.getAuthorities());
     }
 }
-

--- a/src/main/java/com/pentoryall/settlement/controller/UserSettlementController.java
+++ b/src/main/java/com/pentoryall/settlement/controller/UserSettlementController.java
@@ -26,11 +26,11 @@ public class UserSettlementController {
 
     private final UserSettlementService userSettlementService;
 
-
     private final MessageSourceAccessor messageSourceAccessor;
 
     @GetMapping
-    public String userSettlement(@AuthenticationPrincipal UserDTO sessionUser, Model model) throws AuthenticationException {
+    public String userSettlement(@AuthenticationPrincipal UserDTO sessionUser,
+                                 Model model) throws AuthenticationException {
         UserSettlementDTO selectedUserSettlement = userSettlementService.selectByUserCode(sessionUser.getCode());
         if (selectedUserSettlement == null) {
             model.addAttribute("userSettlement", new UserSettlementDTO());
@@ -38,21 +38,24 @@ public class UserSettlementController {
             model.addAttribute("userSettlement", selectedUserSettlement);
         }
 
+        model.addAttribute("SETTINGS_ASIDE", "user-settlement");
         return "views/user/settlement/add";
     }
 
     @PostMapping
 
     public String saveUserSettlement(@ModelAttribute("userSettlement") UserSettlementDTO modifyUserSettlement,
-                                     @AuthenticationPrincipal UserDTO sessionUser, RedirectAttributes rttr) {
+                                     @AuthenticationPrincipal UserDTO sessionUser,
+                                     RedirectAttributes rttr) {
+
         if (modifyUserSettlement.getUserCode() == null) {
             modifyUserSettlement.setUserCode(sessionUser.getCode());
         }
 
         userSettlementService.insertNewUserSettlement(modifyUserSettlement);
+
         rttr.addFlashAttribute("alertMessage", messageSourceAccessor.getMessage("save.success"));
 
         return "redirect:/settings/user/settlement";
-
     }
 }

--- a/src/main/java/com/pentoryall/user/controller/UserController.java
+++ b/src/main/java/com/pentoryall/user/controller/UserController.java
@@ -139,7 +139,8 @@ public class UserController {
 
     /* 회원정보 수정 페이지로 */
     @GetMapping("/update")
-    public String updatePage() {
+    public String updatePage(Model model) {
+        model.addAttribute("SETTINGS_ASIDE", "user-update");
         return "views/user/myModify";
     }
 
@@ -171,9 +172,9 @@ public class UserController {
             /* 상단에 IMAGE_DIR 추가 */
             String filePath = IMAGE_DIR + "profile-images";
             System.out.println("filePath = " + filePath);
-            String originFileName = profile.getOriginalFilename();//업로드 파일명
-            String ext = originFileName.substring(originFileName.lastIndexOf("."));//업로드 파일명에서 확장자 분리
-            String savedName = UUID.randomUUID() + ext;//고유한 파일명 생성 + 확장자 추가
+            String originFileName = profile.getOriginalFilename();// 업로드 파일명
+            String ext = originFileName.substring(originFileName.lastIndexOf("."));// 업로드 파일명에서 확장자 분리
+            String savedName = UUID.randomUUID() + ext;// 고유한 파일명 생성 + 확장자 추가
 
             String finalFilePath = filePath + "/" + savedName;
             System.out.println("finalFilePath = " + finalFilePath);
@@ -219,11 +220,11 @@ public class UserController {
         log.info("login user : {}", user);
         System.out.println(password);
 
-//        /* 회원을 db에서 삭제 */
-//        userService.removeUser(user);
-//
-//        /* 성공적으로 탈퇴한 경우 메시지를 전달하고 로그인 페이지로 리다이렉트 */
-//        rttr.addFlashAttribute("message", "성공적으로 탈퇴되었습니다. 다시 로그인해주세요.");
+        //        /* 회원을 db에서 삭제 */
+        //        userService.removeUser(user);
+        //
+        //        /* 성공적으로 탈퇴한 경우 메시지를 전달하고 로그인 페이지로 리다이렉트 */
+        //        rttr.addFlashAttribute("message", "성공적으로 탈퇴되었습니다. 다시 로그인해주세요.");
 
         // 사용자가 입력한 비밀번호를 인코딩하여 저장된 비밀번호와 비교
         if (passwordEncoder.matches(password, user.getPassword())) {
@@ -281,8 +282,8 @@ public class UserController {
             String tempPw = passwordEncoder.encode(findPwMail.sendSimpleMessage(user.getEmail()));
 
             System.out.println("tempPw : " + tempPw);
-//            // 임시 패스워드 db 에 저장
-//            ms.changeTempPw(tempPw, user.getMno());
+            //            // 임시 패스워드 db 에 저장
+            //            ms.changeTempPw(tempPw, user.getMno());
 
             // 임시 패스워드 발급 완료 메시지를 클라이언트에게 반환합니다.
             return ResponseEntity.ok("success");

--- a/src/main/resources/static/css/sub.css
+++ b/src/main/resources/static/css/sub.css
@@ -41,17 +41,22 @@
 .settings-wrap .content { padding: 80px 40px 0 } 
 .settings-wrap .sub-content { margin-left: 40px; margin-right: 40px}
 
-.settings-wrap .settings-aside { width: 180px; min-width: 180px; height: calc(100vh - 81px); padding: 20px; border-right: 1px solid #ddd; vertical-align: middle; } 
-.settings-wrap .settings-nav .bi { width: 30px; padding-right: 4px; font-size: 20px } 
-.settings-wrap .settings-nav .depth1-li.on .depth1-btn { font-weight: bold; } 
-.settings-wrap .settings-nav .depth1-btn { padding-bottom: 12px } 
-.settings-wrap .settings-nav .depth1-text { font-size: 18px } 
+.settings-wrap .settings-aside { width: 200px; min-width: 180px; height: calc(100vh - 81px); padding: 20px; border-right: 1px solid #ddd; vertical-align: middle; }
+.settings-wrap .settings-nav .bi { width: 30px; padding-right: 4px; font-size: 20px }
+.settings-wrap .settings-nav .depth1-li {margin: 0 0 20px}
+.settings-wrap .settings-nav .depth1-btn { padding-bottom: 12px }
+.settings-wrap .settings-nav .depth1-text { font-size: 18px }
+.settings-wrap .settings-nav .depth2-li{transition: background-color .25s}
+.settings-wrap .settings-nav .depth2-li:hover,
+.settings-wrap .settings-nav .depth2-li.active{background: #efefef; border-radius: 7px}
+.settings-wrap .settings-nav .depth2-li.active a{color:#333; font-weight:600}
 .settings-wrap .settings-nav .depth2-text { padding-left: 30px; color: #666; font-size: 16px; } 
 
 /* .settings-wrap .inner { margin-left: } */
-.nav-depth1 > li { margin-bottom: 7px } 
-.settings-aside li { padding: 7px 0 } 
-.settings-aside li a { display: flex; align-items: center; } 
+.nav-depth1 > li { margin-bottom: 7px }
+
+.settings-aside li { margin:2px 0;  }
+.settings-aside li a { display: flex; align-items: center; padding: 7px 0 }
 
 /* user ======================================== */
 .input_box select { width: 100%; padding: 15px; border: 1px solid #CECECE; border-radius: 5px; } 

--- a/src/main/resources/templates/fragments/settings/sidebar.html
+++ b/src/main/resources/templates/fragments/settings/sidebar.html
@@ -11,16 +11,16 @@
             <!-- [스토리 > 설정] 사이드 메뉴 -->
             <nav class="settings-nav">
                 <ul class="nav-depth1">
-                    <li class="depth1-li on">
+                    <li class="depth1-li">
                         <button class="depth1-btn">
                             <i class="bi bi-person"></i>
                             <span class="depth1-text">계정</span>
                         </button>
                         <ul class="nav-depth2">
-                            <li class="depth2-li">
+                            <li class="depth2-li" th:classappend="${SETTINGS_ASIDE} == 'user-update' ? 'active' : ''">
                                 <a th:href="@{/user/update}" href="/user/update" class="depth2-text">회원 정보</a>
                             </li>
-                            <li class="depth2-li">
+                            <li class="depth2-li" th:classappend="${SETTINGS_ASIDE} == 'user-settlement'? 'active' : ''">
                                 <a th:href="@{/settings/user/settlement}" href="/settings/user/settlement"
                                    class="depth2-text">계좌 정보</a>
                             </li>
@@ -32,7 +32,7 @@
                             <span class="depth1-text">포스트</span>
                         </button>
                         <ul class="nav-depth2">
-                            <li class="depth2-li">
+                            <li class="depth2-li" th:classappend="${SETTINGS_ASIDE} == 'paid-post'? 'active' : ''">
                                 <a th:href="@{#}" href="#" class="depth2-text">유료 포스트 수정</a>
                             </li>
                         </ul>
@@ -43,15 +43,15 @@
                             <span class="depth1-text">수익/정산</span>
                         </button>
                         <ul class="nav-depth2">
-                            <li class="depth2-li">
+                            <li class="depth2-li" th:classappend="${SETTINGS_ASIDE} == 'settlement'? 'active' : ''">
                                 <a th:href="@{/settings/settlement}" href="/settings/settlement" class="depth2-text">정산
                                     요청</a>
                             </li>
-                            <li class="depth2-li">
+                            <li class="depth2-li" th:classappend="${SETTINGS_ASIDE} == 'settlement-list'? 'active' : ''">
                                 <a th:href="@{/settings/settlement/list}" href="/settings/settlement/list"
                                    class="depth2-text">정산 요청 내역</a>
                             </li>
-                            <li class="depth2-li">
+                            <li class="depth2-li" th:classappend="${SETTINGS_ASIDE} == 'revenue-list'? 'active' : ''">
                                 <a th:href="@{/settings/revenue/list}" href="/settings/revenue/list"
                                    class="depth2-text">수익 적립 내역</a>
                             </li>
@@ -63,7 +63,7 @@
                             <span class="depth1-text">멤버십</span>
                         </button>
                         <ul class="nav-depth2">
-                            <li class="depth2-li">
+                            <li class="depth2-li" th:classappend="${SETTINGS_ASIDE} == 'membership'? 'active' : ''">
                                 <a th:href="@{#}" href="#" class="depth2-text">멤버십 관리</a>
                             </li>
                         </ul>
@@ -100,8 +100,7 @@
                                    class="depth2-text">댓글 신고</a>
                             </li>
                             <li class="depth2-li">
-                                <a th:href="@{/admin/report/posts}" href="/admin/report/posts" class="depth2-text">포스트
-                                    신고</a>
+                                <a th:href="@{/admin/report/posts}" href="/admin/report/posts" class="depth2-text">포스트 신고</a>
                             </li>
                         </ul>
                     </li>


### PR DESCRIPTION
<!-- --------------------------------------------------------- -->
<!-- 제목 작성 규칙✅ : #이슈번호 이슈명 -->
<!-- [예시] #23 로그인 페이지 추가 -->
<!-- --------------------------------------------------------- -->


## Summary
🚀 closed #177
<!-- 개요 작성 규칙✅ : PR 개요 및 이슈 번호를 입력하세요. --> 
<!-- 단, 종료된 이슈라면 closed #{이슈번호} 형태로 입력하세요. --> 
<!-- [예시] 🚀 #21 -->


## Details
- 설정 (관리자 페이지도 함께 사용하는) 사이드 메뉴의 `active` 처리 추가
  - 경로는 `/templates/fragments/settings/sidebar` 
  - 관련 controller, css, html 수정됨 

## 스크린샷
<details>
<summary>설정 > 사이드 메뉴 변경 후</summary>

<img width="925" alt="스크린샷 2024-04-11 014942" src="https://github.com/2024-KDT-JNA/Pentoryall/assets/42160693/2fa34e0d-e1b5-4265-ae7f-3bfddc2cb77c">
</details> 


<!-- --------------------------------------------------------- -->
<!-- PR 작성 시 확인 목록✅ -->
<!-- 1) 이슈와 기능에 맞는 라벨(label) 선택 -->
<!-- 2) 프로젝트(project) 선택 -->
<!-- 3) 마일스톤(milestone)선택 -->
<!-- --------------------------------------------------------- -->
